### PR TITLE
Include velocity of arrows in spawn packet - fixes client velocity delay, when shooting arrows

### DIFF
--- a/src/main/java/bullseye/entities/projectile/EntityBEArrow.java
+++ b/src/main/java/bullseye/entities/projectile/EntityBEArrow.java
@@ -15,14 +15,12 @@ import bullseye.particle.BEParticleTypes;
 import net.minecraft.advancements.CriteriaTriggers;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockLiquid;
-import net.minecraft.block.BlockTNT;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.IProjectile;
-import net.minecraft.entity.MoverType;
 import net.minecraft.entity.effect.EntityLightningBolt;
 import net.minecraft.entity.item.EntityTNTPrimed;
 import net.minecraft.entity.monster.EntityEnderman;
@@ -57,10 +55,11 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.common.registry.IThrowableEntity;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class EntityBEArrow extends EntityArrow implements IProjectile
+public class EntityBEArrow extends EntityArrow implements IProjectile, IThrowableEntity
 {    
 	private static final Predicate<Entity> ARROW_TARGETS = Predicates.and(new Predicate[] {EntitySelectors.NOT_SPECTATING, EntitySelectors.IS_ALIVE, new Predicate<Entity>()
 	{
@@ -1251,5 +1250,17 @@ public class EntityBEArrow extends EntityArrow implements IProjectile
 
             return values()[ordinal];
         }
+    }
+
+    @Override
+    public Entity getThrower()
+    {
+        return shootingEntity;
+    }
+
+    @Override
+    public void setThrower( Entity entity )
+    {
+        shootingEntity = entity;
     }
 }

--- a/src/main/java/bullseye/entities/projectile/EntityDyeArrow.java
+++ b/src/main/java/bullseye/entities/projectile/EntityDyeArrow.java
@@ -10,11 +10,9 @@ import com.google.common.base.Predicates;
 import bullseye.api.BEItems;
 import bullseye.item.ItemDyeArrow;
 import net.minecraft.block.Block;
-import net.minecraft.block.BlockBed;
 import net.minecraft.block.BlockColored;
 import net.minecraft.block.BlockConcretePowder;
 import net.minecraft.block.BlockGlazedTerracotta;
-import net.minecraft.block.BlockHorizontal;
 import net.minecraft.block.material.Material;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -40,8 +38,6 @@ import net.minecraft.network.datasync.DataParameter;
 import net.minecraft.network.datasync.DataSerializers;
 import net.minecraft.network.datasync.EntityDataManager;
 import net.minecraft.network.play.server.SPacketChangeGameState;
-import net.minecraft.tileentity.TileEntity;
-import net.minecraft.tileentity.TileEntityBed;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EntitySelectors;
 import net.minecraft.util.EnumFacing;
@@ -54,10 +50,11 @@ import net.minecraft.util.math.MathHelper;
 import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.common.registry.IThrowableEntity;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class EntityDyeArrow extends EntityArrow implements IProjectile
+public class EntityDyeArrow extends EntityArrow implements IProjectile, IThrowableEntity
 {    
 	private static final Predicate<Entity> ARROW_TARGETS = Predicates.and(new Predicate[] {EntitySelectors.NOT_SPECTATING, EntitySelectors.IS_ALIVE, new Predicate<Entity>()
 	{
@@ -873,5 +870,17 @@ public class EntityDyeArrow extends EntityArrow implements IProjectile
 
             return values()[ordinal];
         }
+    }
+
+    @Override
+    public Entity getThrower()
+    {
+        return shootingEntity;
+    }
+    
+    @Override
+    public void setThrower( Entity entity )
+    {
+        shootingEntity = entity;
     }
 }

--- a/src/main/java/bullseye/init/ModEntities.java
+++ b/src/main/java/bullseye/init/ModEntities.java
@@ -26,10 +26,10 @@ public class ModEntities
     public static void init()
     {
         // projectiles
-    	registerBEEntity(EntityDyeArrow.class, "dye_arrow", 64, 3, true);
-        registerBEEntity(EntityBEArrow.class, "arrow", 64, 3, true);
+    	registerBEEntity(EntityDyeArrow.class, "dye_arrow", 64, 20, false);
+        registerBEEntity(EntityBEArrow.class, "arrow", 64, 20, false);
     }
-    
+
     // register an entity
     public static int registerBEEntity(Class<? extends Entity> entityClass, String entityName, int trackingRange, int updateFrequency, boolean sendsVelocityUpdates)
     {


### PR DESCRIPTION
You may have noticed, when shooting arrows, it takes a moment for them to actually start flying, visually. This is caused by velocity information not being included in the spawn packet for the arrows, which means that the client has no knowledge of the motion of the arrow, until the next velocity update is received.

Forge only sends velocity information in the entity spawn packet, if it implements IThrowableEntity (the relevant code can by found at EntitySpawnHandler#spawnEntity). Therefore, I've implemented that interface in both of the Arrow Entities. Though these entities aren't technically "Throwable", that does not matter, as the interface is only used in the aforementioned spawnEntity method.

The second thing I have done is to disable velocityUpdates and change updateFrequency to 20. This was done to mimic the values and behavior of the vanilla arrows, which seems to be the intention. The relevant method to see the vanilla values for this is EntityTracker#track, where EntityArrow can be seen to have disabled velocityUpdates and an updateFrequency of 20. This should be better for server performance, with sending packets 6-7 times less often and not including velocity in those update packets.

I believe the velocityUpdates had previously been set to 3 to counter the arrow spawning without velocity, such that it would receive it as soon as possible. However, with my first change, that should not be necessary anymore.